### PR TITLE
Uniform labels across dictionary, MarkDown and example CIF files

### DIFF
--- a/Examples/ReadMe.md
+++ b/Examples/ReadMe.md
@@ -15,7 +15,7 @@ The goal of these examples is to illustrate:
 
 ## Index
 
-The table below summarizes the core concept, domain, and specific dictionary fields highlighted in each self-contained
+The table below summarises the core concept, domain, and specific dictionary fields highlighted in each self-contained
 example folder.
 
 | Folder Name                                           | Primary Domain | Input Description                        | Key Input/Methodology                                                                   | Core Concepts & Dictionary Fields Highlighted                                                                                                            |


### PR DESCRIPTION
We've created a series of (sub)categories of CSP and COMPCHEM to better divide the data fields by application and to assign them the "Loop" or "Set" class. Markdown files and examples have been changed accordingly.
Changes from the last commit can be seen here: 
https://github.com/COMCIFS/Structure_Prediction_Dictionary/pull/17/commits/4dcd40793da6a7771407422bb05be033580eb471